### PR TITLE
Fix compiling with -fno-common

### DIFF
--- a/src/capture_defs.h
+++ b/src/capture_defs.h
@@ -30,12 +30,12 @@
 #define READ_TIMEOUT                    500
 #define SNAPLEN_DEFAULT                 68
 
-u_int16_t g_display;
-u_int16_t g_link_layer;
-u_int16_t g_dump_pkt;
-u_int16_t g_time_gmt;
-u_int16_t g_t_rst;
-u_int16_t g_snap_len;
-u_int32_t g_pkt_rst;
+extern u_int16_t g_display;
+extern u_int16_t g_link_layer;
+extern u_int16_t g_dump_pkt;
+extern u_int16_t g_time_gmt;
+extern u_int16_t g_t_rst;
+extern u_int16_t g_snap_len;
+extern u_int32_t g_pkt_rst;
 
 #endif /* __CAPTURE_DEFS_H */

--- a/src/error.c
+++ b/src/error.c
@@ -26,6 +26,8 @@
 
 #include "error.h"
 
+char error_buf[ERRBUF_MAXLEN];
+
 void
 fatal_error(char *err,...)
 {

--- a/src/error.h
+++ b/src/error.h
@@ -33,7 +33,7 @@
 #define SUCCESS           		1
 #define FAILURE           		-1
 
-char error_buf[ERRBUF_MAXLEN];
+extern char error_buf[ERRBUF_MAXLEN];
 
 void fatal_error(char *,...);
 

--- a/src/globals.h
+++ b/src/globals.h
@@ -138,20 +138,20 @@
 #define P_INT64                         0x7FFFFFFFFFFFFFFF
 #define P_UINT64                        0xFFFFFFFFFFFFFFFF
 
-char g_w_file[OPT_MAXLEN];
-char g_r_file[OPT_MAXLEN];
+extern char g_w_file[OPT_MAXLEN];
+extern char g_r_file[OPT_MAXLEN];
 
-pcap_t *g_pkt;
-u_int8_t g_tr_fin;
-char *g_filter;
-char *g_device;
-u_int16_t g_hdr_len;
-u_int16_t g_pkt_len;
-u_int16_t g_verbose;
-u_int16_t g_resolve;
-u_int16_t g_p_mode;
-u_int64_t g_cnt;
-u_int64_t g_inj_cnt;
-u_int64_t g_cap_cnt;
+extern pcap_t *g_pkt;
+extern u_int8_t g_tr_fin;
+extern char *g_filter;
+extern char *g_device;
+extern u_int16_t g_hdr_len;
+extern u_int16_t g_pkt_len;
+extern u_int16_t g_verbose;
+extern u_int16_t g_resolve;
+extern u_int16_t g_p_mode;
+extern u_int64_t g_cnt;
+extern u_int64_t g_inj_cnt;
+extern u_int64_t g_cap_cnt;
 
 #endif /* __GLOBALS_H */

--- a/src/inject_defs.h
+++ b/src/inject_defs.h
@@ -30,7 +30,7 @@
 #ifndef __INJECTION_STRUCTS_H
 #define __INJECTION_STRUCTS_H
 
-struct ip4hdr_opts
+extern struct ip4hdr_opts
 {
     u_int16_t p;                   /* protocol type */
     u_int16_t rand_p;
@@ -59,7 +59,7 @@ struct ip4hdr_opts
     u_int16_t rand_d_addr;
 } g_ip4hdr_o;
 
-struct tcphdr_opts
+extern struct tcphdr_opts
 {
     u_int16_t s_port;              /* tcp source port */
     u_int16_t d_port;              /* tcp destination port */
@@ -82,7 +82,7 @@ struct tcphdr_opts
 
 } g_thdr_o;
 
-struct udphdr_opts
+extern struct udphdr_opts
 {
     u_int16_t s_port;              /* udp source port */
     u_int16_t d_port;              /* udp destination port */
@@ -90,7 +90,7 @@ struct udphdr_opts
     u_int16_t sum;                      /* udp checksum */
 } g_uhdr_o;
 
-struct icmp4hdr_opts
+extern struct icmp4hdr_opts
 {
     u_int16_t type;                /* icmp4 type */
     u_int16_t code;                /* icmp4 code */
@@ -132,7 +132,7 @@ struct icmp4hdr_opts
     u_int32_t ttime;                    /* transmit timestamp */
 } g_i4hdr_o;
 
-struct enethdr_opts
+extern struct enethdr_opts
 {
     u_int16_t rand_s_addr;
     u_int16_t rand_d_addr;
@@ -143,7 +143,7 @@ struct enethdr_opts
     u_int8_t dhw_addr[18];
 } g_ehdr_o;
 
-struct arphdr_opts
+extern struct arphdr_opts
 {
     u_int16_t op_type;                  /* arp operation */
 
@@ -163,28 +163,28 @@ struct arphdr_opts
     u_int8_t rhw_addr[18];
 } g_ahdr_o;
 
-libnet_t *g_pkt_d;
+extern libnet_t *g_pkt_d;
 
-u_int16_t g_init_type;
-u_int16_t g_rand_d_port;
-u_int16_t g_rand_s_port;
-u_int16_t g_s_port;
-u_int16_t g_d_port;
-u_int16_t g_port_range;
-u_int16_t g_interval_sec;
-u_int16_t g_interval_usec;
-u_int16_t g_injection_type;
-u_int16_t g_r_timeout;
-u_int16_t g_burst_rate;
-u_int16_t g_payload_len;
-u_int8_t *g_payload;
-u_int8_t g_hex_payload;
-u_int8_t *g_s_d_port;
-u_int8_t g_hwaddr_p[18];
-u_int8_t g_rawip;
+extern u_int16_t g_init_type;
+extern u_int16_t g_rand_d_port;
+extern u_int16_t g_rand_s_port;
+extern u_int16_t g_s_port;
+extern u_int16_t g_d_port;
+extern u_int16_t g_port_range;
+extern u_int16_t g_interval_sec;
+extern u_int16_t g_interval_usec;
+extern u_int16_t g_injection_type;
+extern u_int16_t g_r_timeout;
+extern u_int16_t g_burst_rate;
+extern u_int16_t g_payload_len;
+extern u_int8_t *g_payload;
+extern u_int8_t g_hex_payload;
+extern u_int8_t *g_s_d_port;
+extern u_int8_t g_hwaddr_p[18];
+extern u_int8_t g_rawip;
 
-struct timeval g_bf_pcap;
-struct timeval g_af_pcap;
+extern struct timeval g_bf_pcap;
+extern struct timeval g_af_pcap;
 
 
 #endif /* __INJECTION_STRUCTS_H */

--- a/src/main.c
+++ b/src/main.c
@@ -30,6 +30,62 @@
 
 #include "main.h"
 
+char g_w_file[OPT_MAXLEN];
+char g_r_file[OPT_MAXLEN];
+
+pcap_t *g_pkt;
+u_int8_t g_tr_fin;
+char *g_filter;
+char *g_device;
+u_int16_t g_hdr_len;
+u_int16_t g_pkt_len;
+u_int16_t g_verbose;
+u_int16_t g_resolve;
+u_int16_t g_p_mode;
+u_int64_t g_cnt;
+u_int64_t g_inj_cnt;
+u_int64_t g_cap_cnt;
+
+/* capture_defs.h */
+u_int16_t g_display;
+u_int16_t g_link_layer;
+u_int16_t g_dump_pkt;
+u_int16_t g_time_gmt;
+u_int16_t g_t_rst;
+u_int16_t g_snap_len;
+u_int32_t g_pkt_rst;
+
+/* inject_defs.h */
+u_int16_t g_init_type;
+u_int16_t g_rand_d_port;
+u_int16_t g_rand_s_port;
+u_int16_t g_s_port;
+u_int16_t g_d_port;
+u_int16_t g_port_range;
+u_int16_t g_interval_sec;
+u_int16_t g_interval_usec;
+u_int16_t g_injection_type;
+u_int16_t g_r_timeout;
+u_int16_t g_burst_rate;
+u_int16_t g_payload_len;
+u_int8_t *g_payload;
+u_int8_t g_hex_payload;
+u_int8_t *g_s_d_port;
+u_int8_t g_hwaddr_p[18];
+u_int8_t g_rawip;
+
+struct timeval g_bf_pcap;
+struct timeval g_af_pcap;
+
+struct arphdr_opts g_ahdr_o;
+struct enethdr_opts g_ehdr_o;
+struct icmp4hdr_opts g_i4hdr_o;
+struct ip4hdr_opts g_ip4hdr_o;
+struct tcphdr_opts g_thdr_o;
+struct udphdr_opts g_uhdr_o;
+
+libnet_t *g_pkt_d;
+
 void
 parse_capture_options(int argc, char *argv[])
 {


### PR DESCRIPTION
With GCC 10, -fno-common will be enabled by default[0], causing linker
errors[1] such as:

ld: define_defaults.o:(.bss+0x18): multiple definition of `g_p_mode';
init.o:(.bss+0x18): first defined here

Declare these variables as extern in the headers files and define them
once.

[0] https://gcc.gnu.org/gcc-10/porting_to.html#common
[1] https://bugs.gentoo.org/706520